### PR TITLE
chore(security): bump groovy-all past critical advisories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>1.8.4</version>
+      <version>2.4.21</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -42,7 +42,7 @@
         <artifactId>gmaven-plugin</artifactId>
         <version>1.4</version>
         <configuration>
-          <providerSelection>1.8</providerSelection>
+          <providerSelection>2.0</providerSelection>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Summary
- Raise org.codehaus.groovy:groovy-all from 1.8.4 to 2.4.21 (covers CVE floors 2.4.4 and 2.4.8) and align gmaven providerSelection.
- Clears Dependabot critical alerts (projected until merge).

## Test plan
- [ ] CI / build passes on this branch
- [ ] After merge, Dependabot critical count drops to 0